### PR TITLE
Fix pressure calculation.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ impl Ruuvi {
         if self.pressure == 65535 {
             None
         } else {
-            Some(self.pressure as i32 - 50000)
+            Some(self.pressure as i32 + 50000)
         }
     }
     fn preprocess_accel(accel: i16) -> Option<i16> {


### PR DESCRIPTION
The documentation gives these exemplars for the correct pressure calculation:

00000	50000 Pa
51325	101325 Pa (average sea-level pressure)
65534	115534 Pa
65535	Invalid / not available

meaning that we ought to add 50000 to the u16 raw value, not subtract 50000.